### PR TITLE
fix: add fallback chatbot response for all error scenarios, disclaimer update

### DIFF
--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -248,8 +248,7 @@
       }
 
       let message =
-        "Something unexpected went wrong while processing your request. Please try again in a moment.";
-
+        "Something unexpected went wrong. Please try asking your question again."
       if (err instanceof Error && err.name === "AbortError") {
         message =
           "The request took too long and timed out. Please try again later.";

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -240,13 +240,13 @@
       };
       appendMessage(assistantMessage);
     } catch (err) {
+      let message =
+        "Something unexpected went wrong while processing your request. Please try again in a moment.";
+
       if (err instanceof Error && err.name === "AbortError") {
-        return;
-      }
-
-      let message = "Something unexpected went wrong. Please try again later.";
-
-      if (err instanceof Error && err.message === "INVALID_JSON") {
+        message =
+          "The request took too long and timed out. Please try again later.";
+      } else if (err instanceof Error && err.message === "INVALID_JSON") {
         message =
           "Unexpected response from the server. Please try again later.";
       } else if (err instanceof Error && err.message === "INSECURE_PROTOCOL") {
@@ -269,6 +269,15 @@
         message =
           "There was a problem with this request. Please double-check and try again.";
       }
+
+      // Always add a fallback assistant message when an error occurs
+      const fallbackMessage: ChatMessage = {
+        id: `assistant-error-${Date.now()}`,
+        role: "assistant",
+        content: message,
+        createdAt: Date.now(),
+      };
+      appendMessage(fallbackMessage);
 
       error = message;
     } finally {
@@ -573,7 +582,7 @@
           regarding accuracy, completeness, or reliability.
         </p>
         <p>
-          <strong>No Financial Advice:</strong> Nothing here constitutes financial,
+          <strong>Not Financial Advice:</strong> Nothing here constitutes financial,
           investment, tax, accounting, legal, or professional advice. Do not use
           the Chatbot for financial decisions.
         </p>

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -248,7 +248,7 @@
       }
 
       let message =
-        "Something unexpected went wrong. Please try asking your question again."
+        "Something unexpected went wrong. Please try asking your question again.";
       if (err instanceof Error && err.name === "AbortError") {
         message =
           "The request took too long and timed out. Please try again later.";

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -170,7 +170,7 @@
     input = "";
     abortController = new AbortController();
     const timeoutId = window.setTimeout(() => {
-      abortController?.abort();
+      abortController?.abort(new Error("TIMEOUT"));
     }, REQUEST_TIMEOUT_MS);
 
     try {
@@ -240,6 +240,13 @@
       };
       appendMessage(assistantMessage);
     } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        const reason = abortController?.signal?.reason;
+        if (reason instanceof Error && reason.message === "UNMOUNT") {
+          return; // Silent cleanup on unmount
+        }
+      }
+
       let message =
         "Something unexpected went wrong while processing your request. Please try again in a moment.";
 
@@ -278,8 +285,6 @@
         createdAt: Date.now(),
       };
       appendMessage(fallbackMessage);
-
-      error = message;
     } finally {
       isSending = false;
       abortController = null;
@@ -363,7 +368,7 @@
 
       // Abort any in-flight requests on unmount
       if (abortController) {
-        abortController.abort();
+        abortController.abort(new Error("UNMOUNT"));
       }
       window.clearTimeout(promptTimer);
     };


### PR DESCRIPTION
## Description
- Fixed silent AbortError (timeout) handling - now displays timeout message
- Added fallback ChatMessage creation for all errors in catch block
- Users always receive a visible chatbot response, even during failures
- Update disclaimer copy: `No Financial Advice` to `Not Financial Advice`

## Security Checklist
<!-- Check all that apply -->

### Changes to Sensitive Code
- [ ] This PR modifies `src/lib/secureStorage.ts`
- [ ] This PR modifies `src/lib/walletService.ts`
- [ ] This PR modifies seed phrase display components
- [ ] This PR modifies authentication/authorization logic
- [ ] This PR adds new dependencies

### Security Review
- [ ] No new uses of `innerHTML`, `dangerouslySetInnerHTML`, or `{@html}`
- [ ] All user inputs are properly sanitized
- [ ] No sensitive data logged to console
- [ ] No secrets committed to repository
- [ ] CSP remains strict (no relaxation of policies)
- [ ] HTTPS enforced for all external connections
- [ ] Dependencies scanned for vulnerabilities
- [ ] Changes reviewed by security-aware team member

### Testing
- [ ] Unit tests added/updated
- [ ] Security tests added (if applicable)
- [ ] Tested in production-like environment
- [ ] No console errors or warnings

## Reviewer Notes
<!-- Additional context for reviewers -->
