### PR TITLE
fix: re-add chatbot url to config

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -46,6 +46,11 @@ const config = {
           "https://api.simplesvg.com",
           "https://api.unisvg.com",
           "data:",
+          // NOTE: PUBLIC_WIDGET_API_BASE in .env must match this URL.
+          // If the chatbot backend URL changes, update BOTH:
+          // 1) .env(PUBLIC_WIDGET_API_BASE)
+          // 2) This connect-src entry
+          "https://widget2agent-657488364208.asia-southeast1.run.app",
         ],
         "frame-ancestors": ["none"],
         "base-uri": ["self"],


### PR DESCRIPTION
## Description
- Re-add chatbot cloud run url to svelte config.

## Security Checklist

<!-- Check all that apply -->

### Changes to Sensitive Code

- [ ] This PR modifies `src/lib/secureStorage.ts`
- [ ] This PR modifies `src/lib/walletService.ts`
- [ ] This PR modifies seed phrase display components
- [ ] This PR modifies authentication/authorization logic
- [ ] This PR adds new dependencies

### Security Review

- [ ] No new uses of `innerHTML`, `dangerouslySetInnerHTML`, or `{@html}`
- [ ] All user inputs are properly sanitized
- [ ] No sensitive data logged to console
- [ ] No secrets committed to repository
- [ ] CSP remains strict (no relaxation of policies)
- [ ] HTTPS enforced for all external connections
- [ ] Dependencies scanned for vulnerabilities
- [ ] Changes reviewed by security-aware team member

### Testing

- [ ] Unit tests added/updated
- [ ] Security tests added (if applicable)
- [ ] Tested in production-like environment
- [ ] No console errors or warnings

## Reviewer Notes

<!-- Additional context for reviewers -->
