### PR TITLE
fix: update svelte.config.js to include swapspace URL

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -62,7 +62,7 @@ const config = {
         // Security: Restrict media sources
         "media-src": ["self"],
         // Security: Prevent frame injections (iframe src)
-        "frame-src": ["none"],
+        "frame-src": ["self", "https://swapspace.co/"],
         // Security: Require HTTPS for all requests (upgrade insecure)
         // Disabled in development to allow localhost HTTP
         "upgrade-insecure-requests": process.env.NODE_ENV === "production",


### PR DESCRIPTION
It was removed in https://github.com/DGEN-Technologies/dgen-ui/pull/6/ so this PR adds it back.
