### PR TITLE
hotfix: lightning invoice set amount

### DIFF
--- a/src/routes/(app)/[username]/receive/+page.svelte
+++ b/src/routes/(app)/[username]/receive/+page.svelte
@@ -1585,7 +1585,7 @@
           bind:showQr={$showQr}
           {txt}
           t={$t}
-          showSetAmount={false}
+          showSetAmount={invoiceType === types.lightning}
         />
 
         <!-- Transaction History button - only show for default Lightning view -->


### PR DESCRIPTION
## Description

added back the set amount button for generate invoice for lightning

## Security Checklist

<!-- Check all that apply -->

### Changes to Sensitive Code

- [ ] This PR modifies `svelte.config.js` (CSP/security headers)
- [ ] This PR modifies `src/lib/secureStorage.ts`
- [ ] This PR modifies `src/lib/walletService.ts`
- [ ] This PR modifies seed phrase display components
- [ ] This PR modifies authentication/authorization logic
- [ ] This PR adds new dependencies

### Security Review

- [x] No new uses of `innerHTML`, `dangerouslySetInnerHTML`, or `{@html}`
- [x] All user inputs are properly sanitized
- [x] No sensitive data logged to console
- [x] No secrets committed to repository
- [x] CSP remains strict (no relaxation of policies)
- [x] HTTPS enforced for all external connections
- [x] Dependencies scanned for vulnerabilities
- [x] Changes reviewed by security-aware team member

### Testing

- [ ] Unit tests added/updated
- [ ] Security tests added (if applicable)
- [x] Tested in production-like environment
- [x] No console errors or warnings

## Reviewer Notes

hotfix after seeing dgentech-dev push
