### PR TITLE
hotfix: Switched PUBLIC_WIDGET_API_BASE to dynamic env

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { run } from "svelte/legacy";
   import { browser } from "$app/environment";
-  import { PUBLIC_DOMAIN, PUBLIC_WIDGET_API_BASE } from "$env/static/public";
+  import { env as publicEnv } from "$env/dynamic/public";
+  import { PUBLIC_DOMAIN } from "$env/static/public";
   import "../app-modern.css";
   import { loading, t } from "$lib/translations";
   import { onMount } from "svelte";
@@ -136,7 +137,7 @@
 
 <!-- Chat Widget - loads after initial render -->
 {#if showChatWidget}
-  <ChatWidget apiBase={PUBLIC_WIDGET_API_BASE} {userId} />
+  <ChatWidget apiBase={publicEnv.PUBLIC_WIDGET_API_BASE || ""} {userId} />
 {/if}
 
 <style global>


### PR DESCRIPTION
## Description

Netlify is failing because PUBLIC_WIDGET_API_BASE isn’t defined at build time, but src/routes/+layout.svelte imports it from $env/static/public (which requires it to exist during build). Your local build works because you likely have that env var set locally.

chore: lint

## Security Checklist

<!-- Check all that apply -->

### Changes to Sensitive Code

- [ ] This PR modifies `svelte.config.js` (CSP/security headers)
- [ ] This PR modifies `src/lib/secureStorage.ts`
- [ ] This PR modifies `src/lib/walletService.ts`
- [ ] This PR modifies seed phrase display components
- [ ] This PR modifies authentication/authorization logic
- [ ] This PR adds new dependencies

### Security Review

- [x] No new uses of `innerHTML`, `dangerouslySetInnerHTML`, or `{@html}`
- [x] All user inputs are properly sanitized
- [x] No sensitive data logged to console
- [x] No secrets committed to repository
- [x] CSP remains strict (no relaxation of policies)
- [x] HTTPS enforced for all external connections
- [x] Dependencies scanned for vulnerabilities
- [x] Changes reviewed by security-aware team member

### Testing

- [ ] Unit tests added/updated
- [ ] Security tests added (if applicable)
- [ ] Tested in production-like environment
- [ ] No console errors or warnings

## Reviewer Notes

self-review
