### PR TITLE
fix: handle cold start and improve response formatting

### DIFF
--- a/src/app-modern.css
+++ b/src/app-modern.css
@@ -1038,3 +1038,24 @@ main.pro-mode .landing-page-content * {
     opacity: 0.6;
   }
 }
+
+/* Chatbot bubble: restore paragraph/list formatting that Tailwind Preflight resets.
+   Uses the "lobotomized owl" (> * + *) to handle all adjacent block combinations:
+   p→p, p→ul, ul→p, ul→ul, etc. */
+.bubble.assistant > * + * {
+  margin-top: 0.75em;
+}
+
+.bubble.assistant ul {
+  list-style: disc;
+  padding-left: 1.25em;
+}
+
+.bubble.assistant ol {
+  list-style: decimal;
+  padding-left: 1.25em;
+}
+
+.bubble.assistant li + li {
+  margin-top: 0.2em;
+}

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -382,7 +382,7 @@
     renderSafeMarkdown(intro)
       .then((html) => {
         messages = messages.map((m) =>
-          m.id === introMessage.id ? { ...m, html } : m
+          m.id === introMessage.id ? { ...m, html } : m,
         );
       })
       .catch((err) => {

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -58,11 +58,11 @@
   let disclaimerWindowRef = $state<HTMLDivElement>();
   let disclaimerCloseRef = $state<HTMLButtonElement>();
   let abortController: AbortController | null = null;
+  let mounted = false;
 
   // Helpers for storage keys
   const buildKey = (suffix: string, userId?: string) =>
     `dgen_${suffix}_${userId ?? "anon"}`;
-  const messagesKeyFor = (userId?: string) => buildKey("messages", userId);
   const userKeyFor = (userId?: string) => buildKey("user", userId);
   const tokenKeyFor = (userId?: string) => buildKey("token", userId);
 
@@ -259,8 +259,11 @@
       } catch (firstErr) {
         // On timeout, 5xx, or network error, retry once (cold-start recovery).
         // TypeError covers connection refused / network failure during cold start.
+        // Browsers may throw the abort reason directly (modern) or as a
+        // DOMException with name "AbortError" (older). Handle both.
         const isTimeout =
-          firstErr instanceof Error && firstErr.name === "AbortError";
+          firstErr instanceof Error &&
+          (firstErr.name === "AbortError" || firstErr.message === "TIMEOUT");
         const is5xx =
           firstErr instanceof Error && firstErr.message.startsWith("HTTP_5");
         const isNetworkError = firstErr instanceof TypeError;
@@ -271,6 +274,7 @@
           throw firstErr;
         }
       }
+      if (!mounted) return;
       appendMessage(assistantMessage);
     } catch (err) {
       if (err instanceof Error && err.message === "UNMOUNT") {
@@ -279,7 +283,10 @@
 
       let message =
         "Something unexpected went wrong. Please try asking your question again.";
-      if (err instanceof Error && err.name === "AbortError") {
+      if (
+        err instanceof Error &&
+        (err.name === "AbortError" || err.message === "TIMEOUT")
+      ) {
         message =
           "The request is taking longer than usual. Please try again later.";
       } else if (err instanceof Error && err.message === "INVALID_JSON") {
@@ -375,34 +382,35 @@
       sessionToken = storedToken;
     }
 
-    const mKey = messagesKeyFor(sessionUserId);
-    storage.removeItem(mKey);
-
     const intro =
       "Hello! I'm DGEN AI Assistant, your guide to this DGEN app. How can I help you today?";
 
-    (async () => {
-      messages = [
-        {
-          id: "assistant-intro",
-          role: "assistant",
-          content: intro,
-          createdAt: Date.now(),
-          html: await renderSafeMarkdown(intro).catch((err) => {
-            // Fail closed: drop HTML if markdown render or sanitize fails
-            console.warn("renderSafeMarkdown failed", err);
-            return undefined;
-          }),
-        },
-      ];
-    })();
+    // Set intro synchronously so the message appears immediately (no empty-state flash),
+    // then patch in the rendered HTML once markdown resolves.
+    const introMessage: ChatMessage = {
+      id: "assistant-intro",
+      role: "assistant",
+      content: intro,
+      createdAt: Date.now(),
+    };
+    messages = [introMessage];
+    renderSafeMarkdown(intro)
+      .then((html) => {
+        messages = [{ ...introMessage, html }];
+      })
+      .catch((err) => {
+        // Fail closed: leave html undefined so plain text renders instead
+        console.warn("renderSafeMarkdown failed", err);
+      });
 
+    mounted = true;
     isReady = true;
     const promptTimer = window.setTimeout(() => {
       showPrompt = false;
     }, 3000);
     window.addEventListener("keydown", handleGlobalKeydown);
     return () => {
+      mounted = false;
       window.removeEventListener("keydown", handleGlobalKeydown);
 
       // Abort any in-flight requests on unmount

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -505,6 +505,7 @@
       </div>
       <div>
         <button
+          type="button"
           onclick={toggleOpen}
           class="close-button"
           aria-label="Close chat"

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -31,7 +31,10 @@
   const MAX_MESSAGE_LENGTH = 1000;
   const SEND_COOLDOWN_MS = 300;
   const REQUEST_TIMEOUT_MS = 15000;
+  const COLD_START_TIMEOUT_MS = 45000; // extended timeout for cold-start retry
   const MAX_MESSAGES_STORED = 200;
+  const LABEL_THINKING = "Thinking…";
+  const LABEL_RETRYING = "Still loading, please wait…";
   let lastSendTime = 0;
 
   // State
@@ -46,12 +49,14 @@
   let showPrompt = $state(true);
   let showDisclaimer = $state(false);
   let disclaimerAgreed = $state(false);
+  let isApiBaseValid = $state(true);
+  let sendingLabel = $state(LABEL_THINKING);
 
-  // Refs
-  let bottomRef: HTMLDivElement;
-  let textareaRef: HTMLTextAreaElement;
-  let disclaimerWindowRef: HTMLDivElement;
-  let disclaimerCloseRef: HTMLButtonElement;
+  // Ref
+  let bottomRef = $state<HTMLDivElement>();
+  let textareaRef = $state<HTMLTextAreaElement>();
+  let disclaimerWindowRef = $state<HTMLDivElement>();
+  let disclaimerCloseRef = $state<HTMLButtonElement>();
   let abortController: AbortController | null = null;
 
   // Helpers for storage keys
@@ -123,6 +128,91 @@
     }
   }
 
+  // Perform a single POST attempt with a given timeout. Throws on any error.
+  // Throws Error("UNMOUNT") when the widget is torn down mid-request.
+  async function doFetch(
+    text: string,
+    timeoutMs: number,
+  ): Promise<ChatMessage> {
+    abortController = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      abortController?.abort(new Error("TIMEOUT"));
+    }, timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (sessionToken) {
+        headers["X-Session-Token"] = sessionToken;
+      }
+
+      const res = await fetch(apiBase, {
+        method: "POST",
+        headers,
+        signal: abortController.signal,
+        body: JSON.stringify({ message: text }),
+      });
+
+      if (!res.ok) {
+        if (res.status === 401 || res.status === 403) {
+          sessionToken = "";
+          sessionUserId = undefined;
+          throw new Error("AUTH_EXPIRED");
+        }
+        throw new Error(`HTTP_${res.status}`);
+      }
+
+      let data: ChatResponse;
+      try {
+        data = (await res.json()) as ChatResponse;
+      } catch {
+        throw new Error("INVALID_JSON");
+      }
+
+      if (data.user_id) {
+        sessionUserId = data.user_id;
+        window.sessionStorage.setItem(userKeyFor(sessionUserId), sessionUserId);
+      }
+      if (data.session_token) {
+        sessionToken = data.session_token;
+        window.sessionStorage.setItem(
+          tokenKeyFor(sessionUserId),
+          data.session_token,
+        );
+      }
+
+      const answer: string =
+        data.answer ??
+        "I did not receive a response. Please try again in a moment.";
+
+      return {
+        id: `assistant-${Date.now()}`,
+        role: "assistant",
+        content: answer,
+        createdAt: Date.now(),
+        html: await renderSafeMarkdown(answer).catch((err) => {
+          // Fail closed: drop HTML if markdown render or sanitize fails
+          console.warn("renderSafeMarkdown failed", err);
+          return undefined;
+        }),
+      };
+    } catch (err) {
+      // Re-raise unmount aborts as a named error so sendMessage can silently exit.
+      // Must be checked here while abortController is still set (before finally clears it).
+      if (err instanceof Error && err.name === "AbortError") {
+        const reason = abortController?.signal?.reason;
+        if (reason instanceof Error && reason.message === "UNMOUNT") {
+          throw new Error("UNMOUNT");
+        }
+      }
+      throw err;
+    } finally {
+      abortController = null;
+      window.clearTimeout(timeoutId);
+    }
+  }
+
   async function sendMessage() {
     if (!isReady) return;
     if (!disclaimerAgreed) {
@@ -145,129 +235,65 @@
       return;
     }
 
-    // Require https (allow localhost for dev)
-    try {
-      const target = new URL(apiBase);
-      if (target.protocol !== "https:" && target.hostname !== "localhost") {
-        throw new Error("INSECURE_PROTOCOL");
-      }
-    } catch {
+    if (!isApiBaseValid) {
       error = "Chat is not configured correctly. Please try again later.";
       return;
     }
 
     error = null;
     isSending = true;
+    sendingLabel = LABEL_THINKING;
 
-    const userMessage: ChatMessage = {
+    appendMessage({
       id: `user-${Date.now()}`,
       role: "user",
       content: text,
       createdAt: Date.now(),
-    };
-
-    appendMessage(userMessage);
+    });
     input = "";
-    abortController = new AbortController();
-    const timeoutId = window.setTimeout(() => {
-      abortController?.abort(new Error("TIMEOUT"));
-    }, REQUEST_TIMEOUT_MS);
 
     try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-      if (sessionToken) {
-        headers["X-Session-Token"] = sessionToken;
-      }
-
-      const res = await fetch(`${apiBase}`, {
-        method: "POST",
-        headers,
-        signal: abortController.signal,
-        body: JSON.stringify({
-          message: text,
-        }),
-      });
-
-      if (!res.ok) {
-        if (res.status === 401 || res.status === 403) {
-          sessionToken = "";
-          sessionUserId = undefined;
-          throw new Error("AUTH_EXPIRED");
-        }
-        throw new Error(`HTTP_${res.status}`);
-      }
-
-      let data: ChatResponse;
+      let assistantMessage: ChatMessage;
       try {
-        data = (await res.json()) as ChatResponse;
-      } catch (parseErr) {
-        throw new Error("INVALID_JSON");
-      }
-
-      if (data.user_id) {
-        sessionUserId = data.user_id;
-        if (typeof window !== "undefined") {
-          window.sessionStorage.setItem(
-            userKeyFor(sessionUserId),
-            sessionUserId,
-          );
+        assistantMessage = await doFetch(text, REQUEST_TIMEOUT_MS);
+      } catch (firstErr) {
+        // On timeout, 5xx, or network error, retry once (cold-start recovery).
+        // TypeError covers connection refused / network failure during cold start.
+        const isTimeout =
+          firstErr instanceof Error && firstErr.name === "AbortError";
+        const is5xx =
+          firstErr instanceof Error && firstErr.message.startsWith("HTTP_5");
+        const isNetworkError = firstErr instanceof TypeError;
+        if (isTimeout || is5xx || isNetworkError) {
+          sendingLabel = LABEL_RETRYING;
+          assistantMessage = await doFetch(text, COLD_START_TIMEOUT_MS);
+        } else {
+          throw firstErr;
         }
       }
-      if (data.session_token) {
-        sessionToken = data.session_token;
-        if (typeof window !== "undefined") {
-          const tokenKey = tokenKeyFor(sessionUserId);
-          window.sessionStorage.setItem(tokenKey, data.session_token);
-        }
-      }
-
-      const answer: string =
-        data.answer ??
-        "I did not receive a response. Please try again in a moment.";
-
-      const assistantMessage: ChatMessage = {
-        id: `assistant-${Date.now()}`,
-        role: "assistant",
-        content: answer,
-        createdAt: Date.now(),
-        html: await renderSafeMarkdown(answer).catch((err) => {
-          // Fail closed: drop HTML if markdown render or sanitize fails
-          console.warn("renderSafeMarkdown failed", err);
-          return undefined;
-        }),
-      };
       appendMessage(assistantMessage);
     } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") {
-        const reason = abortController?.signal?.reason;
-        if (reason instanceof Error && reason.message === "UNMOUNT") {
-          return; // Silent cleanup on unmount
-        }
+      if (err instanceof Error && err.message === "UNMOUNT") {
+        return; // Silent cleanup on unmount
       }
 
       let message =
         "Something unexpected went wrong. Please try asking your question again.";
       if (err instanceof Error && err.name === "AbortError") {
         message =
-          "The request took too long and timed out. Please try again later.";
+          "The request is taking longer than usual. Please try again later.";
       } else if (err instanceof Error && err.message === "INVALID_JSON") {
         message =
           "Unexpected response from the server. Please try again later.";
-      } else if (err instanceof Error && err.message === "INSECURE_PROTOCOL") {
-        message = "Secure connection required. Please use HTTPS to continue.";
       } else if (err instanceof Error && err.message === "AUTH_EXPIRED") {
-        if (typeof window !== "undefined") {
-          const storage = window.sessionStorage;
-          storage.removeItem(userKeyFor(sessionUserId));
-          storage.removeItem(tokenKeyFor(sessionUserId));
-        }
+        window.sessionStorage.removeItem(userKeyFor(sessionUserId));
+        window.sessionStorage.removeItem(tokenKeyFor(sessionUserId));
         sessionToken = "";
         sessionUserId = undefined;
         message = "Session expired. Please send your message again.";
       } else if (err instanceof TypeError) {
-        message = "Network error - please check your connection and try again.";
+        message =
+          "Unable to reach the server. Please check your connection and try again.";
       } else if (err instanceof Error && err.message.startsWith("HTTP_5")) {
         message =
           "Our server had a problem processing your request. Please try again in a moment.";
@@ -276,18 +302,15 @@
           "There was a problem with this request. Please double-check and try again.";
       }
 
-      // Always add a fallback assistant message when an error occurs
-      const fallbackMessage: ChatMessage = {
+      appendMessage({
         id: `assistant-error-${Date.now()}`,
         role: "assistant",
         content: message,
         createdAt: Date.now(),
-      };
-      appendMessage(fallbackMessage);
+      });
     } finally {
       isSending = false;
-      abortController = null;
-      window.clearTimeout(timeoutId);
+      sendingLabel = LABEL_THINKING;
     }
   }
 
@@ -315,7 +338,24 @@
 
   // Lifecycle - Initialize session and messages
   onMount(() => {
-    if (typeof window === "undefined") return;
+    // Validate apiBase once on mount
+    try {
+      const target = new URL(apiBase);
+      if (target.protocol !== "https:" && target.hostname !== "localhost") {
+        isApiBaseValid = false;
+      }
+    } catch {
+      isApiBaseValid = false;
+    }
+
+    // Warm-up ping: fire a GET to wake the Cloud Run instance while the user
+    // reads the disclaimer and types their first message. Errors are ignored.
+    if (isApiBaseValid) {
+      fetch(apiBase, {
+        method: "GET",
+        signal: AbortSignal.timeout(10000),
+      }).catch(() => {});
+    }
 
     const storage = window.sessionStorage;
 
@@ -375,7 +415,7 @@
 
   // Auto-scroll to bottom
   $effect(() => {
-    if (messages.length > 0 || isOpen) {
+    if (isOpen && messages.length > 0) {
       bottomRef?.scrollIntoView({ behavior: "smooth" });
     }
   });
@@ -446,18 +486,18 @@
     class="widget-container"
     id="dgen-chat-widget"
     role="dialog"
+    aria-modal="true"
     aria-label="DGEN support chat"
   >
     <!-- Header -->
     <div class="header">
       <div class="header-text">
-        <div style="font-weight: 600;">DGEN Chatbot</div>
+        <div class="chatbot-title">DGEN Chatbot</div>
         <button
           type="button"
           class="disclaimer-link"
           onclick={() => {
             showDisclaimer = true;
-            disclaimerAgreed = false;
           }}
         >
           Disclaimer: Read First Before Using This DGEN Chatbot
@@ -484,12 +524,7 @@
       {/if}
 
       {#each messages as m (m.id)}
-        <div
-          class="message-row"
-          style="justify-content: {m.role === 'user'
-            ? 'flex-end'
-            : 'flex-start'};"
-        >
+        <div class="message-row" class:user={m.role === "user"}>
           <div class="bubble {m.role}">
             {#if m.role === "assistant" && m.html}
               {@html m.html}
@@ -501,9 +536,9 @@
       {/each}
 
       {#if isSending}
-        <div class="message-row" style="justify-content: flex-start;">
+        <div class="message-row">
           <div class="bubble assistant">
-            <span style="opacity: 0.7;">Thinking…</span>
+            <span class="sending-label">{sendingLabel}</span>
           </div>
         </div>
       {/if}
@@ -532,12 +567,6 @@
         onclick={sendMessage}
         disabled={!isReady || isSending || !input.trim() || !disclaimerAgreed}
         class="send-button"
-        style="opacity: {!isReady ||
-        isSending ||
-        !input.trim() ||
-        !disclaimerAgreed
-          ? 0.5
-          : 1};"
       >
         ➤
       </button>
@@ -553,6 +582,7 @@
     tabindex="-1"
     onkeydown={trapDisclaimerFocus}
   >
+    <!-- tabindex="-1" allows programmatic focus without adding the element to the tab order -->
     <div
       class="disclaimer-window"
       bind:this={disclaimerWindowRef}
@@ -772,11 +802,23 @@
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 14px;
+  }
+
+  .chatbot-title {
+    font-weight: 600;
   }
 
   .message-row {
     display: flex;
+  }
+
+  .message-row.user {
+    justify-content: flex-end;
+  }
+
+  .sending-label {
+    opacity: 0.7;
   }
 
   .bubble {
@@ -786,12 +828,12 @@
     line-height: 1.4;
     max-width: 80%;
     word-break: break-word;
-    white-space: pre-wrap;
   }
 
   .bubble.user {
     background: var(--widget-bg-user);
     color: var(--widget-text-color);
+    white-space: pre-wrap;
   }
 
   .bubble.assistant {
@@ -801,9 +843,13 @@
 
   .empty-state {
     font-size: 14px;
-    opacity: 0.8;
     text-align: center;
     margin-top: 24px;
+    opacity: 0;
+    transform: translateY(10px);
+    transition:
+      opacity 0.4s ease,
+      transform 0.4s ease;
   }
 
   .error {
@@ -850,6 +896,7 @@
 
   .send-button:disabled {
     cursor: not-allowed;
+    opacity: 0.5;
   }
 
   @media (max-width: 600px) {
@@ -866,14 +913,6 @@
       bottom: 16px;
       right: 16px;
     }
-  }
-
-  .empty-state {
-    opacity: 0;
-    transform: translateY(10px);
-    transition:
-      opacity 0.4s ease,
-      transform 0.4s ease;
   }
 
   .empty-state.ready {
@@ -932,14 +971,6 @@
     margin: 0;
     font-size: clamp(22px, 3vw, 28px);
     color: #e5e7eb;
-  }
-
-  .disclaimer-close {
-    border: none;
-    background: transparent;
-    color: #d1d5db;
-    font-size: 18px;
-    cursor: pointer;
   }
 
   .disclaimer-body {

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -30,11 +30,11 @@
   // Config
   const MAX_MESSAGE_LENGTH = 1000;
   const SEND_COOLDOWN_MS = 300;
-  const REQUEST_TIMEOUT_MS = 15000;
-  const COLD_START_TIMEOUT_MS = 45000; // extended timeout for cold-start retry
+  const REQUEST_TIMEOUT_MS = 60000;
+  const REASSURE_DELAY_MS = 30000; // switch label after 30s to reassure the user
   const MAX_MESSAGES_STORED = 200;
   const LABEL_THINKING = "Thinking…";
-  const LABEL_RETRYING = "Still loading, please wait…";
+  const LABEL_REASSURE = "Still thinking, please wait…";
   let lastSendTime = 0;
 
   // State
@@ -252,28 +252,12 @@
     });
     input = "";
 
+    const reassureTimer = window.setTimeout(() => {
+      sendingLabel = LABEL_REASSURE;
+    }, REASSURE_DELAY_MS);
+
     try {
-      let assistantMessage: ChatMessage;
-      try {
-        assistantMessage = await doFetch(text, REQUEST_TIMEOUT_MS);
-      } catch (firstErr) {
-        // On timeout, 5xx, or network error, retry once (cold-start recovery).
-        // TypeError covers connection refused / network failure during cold start.
-        // Browsers may throw the abort reason directly (modern) or as a
-        // DOMException with name "AbortError" (older). Handle both.
-        const isTimeout =
-          firstErr instanceof Error &&
-          (firstErr.name === "AbortError" || firstErr.message === "TIMEOUT");
-        const is5xx =
-          firstErr instanceof Error && firstErr.message.startsWith("HTTP_5");
-        const isNetworkError = firstErr instanceof TypeError;
-        if (isTimeout || is5xx || isNetworkError) {
-          sendingLabel = LABEL_RETRYING;
-          assistantMessage = await doFetch(text, COLD_START_TIMEOUT_MS);
-        } else {
-          throw firstErr;
-        }
-      }
+      const assistantMessage = await doFetch(text, REQUEST_TIMEOUT_MS);
       if (!mounted) return;
       appendMessage(assistantMessage);
     } catch (err) {
@@ -316,6 +300,7 @@
         createdAt: Date.now(),
       });
     } finally {
+      window.clearTimeout(reassureTimer);
       isSending = false;
       sendingLabel = LABEL_THINKING;
     }

--- a/src/components/ChatWidget.svelte
+++ b/src/components/ChatWidget.svelte
@@ -381,7 +381,9 @@
     messages = [introMessage];
     renderSafeMarkdown(intro)
       .then((html) => {
-        messages = [{ ...introMessage, html }];
+        messages = messages.map((m) =>
+          m.id === introMessage.id ? { ...m, html } : m
+        );
       })
       .catch((err) => {
         // Fail closed: leave html undefined so plain text renders instead

--- a/src/lib/safeMarkdown.ts
+++ b/src/lib/safeMarkdown.ts
@@ -26,7 +26,7 @@ function ensureDomPurifyHooks() {
 }
 
 marked.setOptions({
-  breaks: false,
+  breaks: true, // render single \n as <br>
   gfm: true, // GitHub-style markdown
 });
 

--- a/src/lib/safeMarkdown.ts
+++ b/src/lib/safeMarkdown.ts
@@ -52,7 +52,7 @@ export async function renderSafeMarkdown(markdown: string): Promise<string> {
       "pre",
     ],
     ALLOWED_ATTR: ["href", "target", "rel"],
-    ALLOWED_URI_REGEXP: /^https?:\/\//i,
+    ALLOWED_URI_REGEXP: /^https:\/\//i,
   });
 
   return cleanHtml;


### PR DESCRIPTION
## Description

### Cold Start Resilience
- Added warm-up GET ping on mount to wake the Cloud Run instance while the user reads the disclaimer and types their first message (errors silently ignored)
- Increased `REQUEST_TIMEOUT_MS` from 15s to 60s to give cold starts sufficient time to respond
- Added "Still thinking, please wait…" label after 30s so users know the request is still in flight
- Extracted `doFetch(text, timeoutMs)` helper to isolate fetch logic from error handling in `sendMessage`
- Moved `apiBase` URL validation to mount (via `isApiBaseValid` flag) rather than re-checking on every send

### Markdown Rendering
- Enabled `breaks: true` in marked so single `\n` renders as `<br>`
- Scoped `white-space: pre-wrap` to user bubbles only — applying it to assistant bubbles caused a blank trailing line from marked's `<p>` wrapping
- Added CSS rules in `app-modern.css` to restore paragraph spacing, bullet/ordered list styles, and list-item gaps inside `.bubble.assistant` — Tailwind Preflight resets these to zero
- Tightened `ALLOWED_URI_REGEXP` from `https?://` to `https://` only, blocking HTTP links in sanitized markdown

### Message Bubble UX
- Increased gap between message bubbles from 10px to 14px
- Added animated fade-in for empty state (consolidated duplicate `.empty-state` CSS rules)

### Accessibility
- Added `aria-modal="true"` to the chat widget container (`role="dialog"`)
- Added `type="button"` to close button to prevent accidental form submission
- Keyboard focus trapping inside the disclaimer modal
- Global Escape key handler to close the widget or dismiss the disclaimer
- Guarded auto-scroll `$effect` to only fire when `isOpen && messages.length > 0`

### Error Handling
- Fixed UNMOUNT detection: `doFetch` re-throws `Error("UNMOUNT")` before `finally` clears `abortController`, so unmount aborts are silently swallowed rather than surfaced as errors
- Mapped all error types to user-friendly messages: timeout/abort, invalid JSON, auth expiry (with session storage cleanup), network error (`TypeError`), 4xx, 5xx
- Removed dead `INSECURE_PROTOCOL` error path (validation now happens at mount)

### Code Quality
- Extracted `LABEL_THINKING` / `LABEL_REASSURE` string constants; `sendingLabel` drives the thinking indicator
- Replaced all inline `style=` attributes with CSS classes (`.chatbot-title`, `.message-row.user`, `.sending-label`, `.send-button:disabled`)
- Declared DOM refs with `$state()` for proper Svelte 5 reactivity
- Removed dead `.disclaimer-close` CSS rule
- Removed redundant `typeof window !== "undefined"` guards inside `onMount`
- Removed `messagesKeyFor` and associated session storage message persistence
- Added `mounted` flag to guard against state updates after component teardown

## Security Checklist

<!-- Check all that apply -->

### Changes to Sensitive Code

- [ ] This PR modifies `svelte.config.js` (CSP/security headers)
- [ ] This PR modifies `src/lib/secureStorage.ts`
- [ ] This PR modifies `src/lib/walletService.ts`
- [ ] This PR modifies seed phrase display components
- [ ] This PR modifies authentication/authorization logic
- [ ] This PR adds new dependencies

### Security Review

- [ ] No new uses of `innerHTML`, `dangerouslySetInnerHTML`, or `{@html}`
- [ ] All user inputs are properly sanitized
- [ ] No sensitive data logged to console
- [ ] No secrets committed to repository
- [ ] CSP remains strict (no relaxation of policies)
- [ ] HTTPS enforced for all external connections
- [ ] Dependencies scanned for vulnerabilities
- [ ] Changes reviewed by security-aware team member

### Testing

- [ ] Unit tests added/updated
- [ ] Security tests added (if applicable)
- [ ] Tested in production-like environment
- [ ] No console errors or warnings

## Reviewer Notes

<!-- Additional context for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a delayed “reassurance” label for long in-progress message sends.

* **Bug Fixes**
  * Restored paragraph and list formatting in assistant chat bubbles.
  * Line breaks in markdown now render as expected.
  * HTTP (non-HTTPS) links are blocked in sanitized message content.

* **Improvements**
  * Clearer user-facing error messages for timeouts and server/network issues.
  * Enhanced chat modal accessibility and refined scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->